### PR TITLE
Restricts the priority script to SM windows

### DIFF
--- a/numpad priorities 10-25-2020.ahk
+++ b/numpad priorities 10-25-2020.ahk
@@ -9,6 +9,12 @@ CoordMode, Mouse, Screen
 #SingleInstance, force
 SetTitleMatchMode,2
 
+GroupAdd, SuperMemo, ahk_class TBrowser ;Browser
+GroupAdd, SuperMemo, ahk_class TContents ;Content Window (Knowledge Tree)
+GroupAdd, SuperMemo, ahk_class TElWind ;Element window
+GroupAdd, SuperMemo, ahk_class TSMMain ;Toolbar
+
+#IfWinActive ahk_group SuperMemo
 Numpad0::
 {
 send, !p


### PR DESCRIPTION
This snippet from Alexis makes the script only activate in SM windows. So you can use the numpad like normal in all other windows.